### PR TITLE
Not all available versions are displayed via list

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -19,7 +19,7 @@ set -eo pipefail
 
 curl_command="curl --silent --location"
 releases_path="https://www.smlnj.org/dist/working/"
-regular_expression="[0-9.]*-README.html"
+regular_expression="[0-9.]*/index.html"
 regular_expression_numbers="[0-9.]*"
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942


### PR DESCRIPTION
The latest release of SML/NJ is `110.98.1`, which was released some time ago:

![image](https://user-images.githubusercontent.com/788303/94840270-057a1d00-03cd-11eb-9804-5eec2a98df88.png)

I was initially confused because `110.98.1` didn't appear via `asdf list all smlnj` (and `asdf latest smlnj`). Once I confirmed it _should_ be available, I was able to install it explicitly.

**Cause**

Looking into the issue I discovered it happens because of an error in the download page's HTML:

```
    <tr>
      <td valign="top"><a href="110.98/110.98-README.html">
        <b>110.98.1</b></a><br>
      </td>
      <td valign="top">August 25, 2020<br>
      </td>
      <td valign="top"><a href="110.98.1/index.html">files</a><br>
      </td>
    </tr>

    <tr>
      <td valign="top"><a href="110.98/110.98-README.html">
        <b>110.98</b></a><br>
      </td>
      <td valign="top">July 16, 2020<br>
      </td>
      <td valign="top"><a href="110.98/index.html">files</a><br>
      </td>
    </tr>
```

(Observer that `<td valign="top"><a href="110.98/110.98-README.html">` appears twice.)

Because `list-all` uses the `README` line to determine the list of versions, `110.98` is duplicated and `110.98.1` is not listed.

**Fix**

This PR simply changes the list of versions to be derived from the version number links, rather than the README links.

Testing:

**Before**

```
[~/.asdf/plugins/smlnj/bin] 2384% ./list-all 
110.42 110.43 110.44 110.45 110.46 110.47 110.48 110.49 110.50 110.51 110.52 110.53 110.54 110.55 110.56 110.57 110.58 110.59 110.60 110.61 110.62 110.63 110.63.1 110.63.2 110.64 110.65 110.66 110.67 110.68 110.69 110.70 110.71 110.72 110.73 110.74 110.75 110.76 110.77 110.78 110.79 110.80 110.81 110.82 110.83 110.84 110.85 110.86 110.87 110.88 110.89 110.90 110.91 110.92 110.93 110.94 110.95 110.96 110.97 110.98 110.98
```

```
[~/.asdf/plugins/smlnj/bin] 2435% asdf latest smlnj
110.98
```

**After**

```
[~/.asdf/plugins/smlnj/bin] 2389% ./list-all
110.42 110.43 110.44 110.45 110.46 110.47 110.48 110.49 110.50 110.51 110.52 110.53 110.54 110.55 110.56 110.57 110.58 110.59 110.60 110.61 110.62 110.63 110.63.1 110.63.2 110.64 110.65 110.66 110.67 110.68 110.69 110.70 110.71 110.72 110.73 110.74 110.75 110.76 110.77 110.78 110.79 110.80 110.81 110.82 110.83 110.84 110.85 110.86 110.87 110.88 110.89 110.90 110.91 110.92 110.93 110.94 110.95 110.96 110.97 110.98 110.98.1
```

```
[~/.asdf/plugins/smlnj/bin] 2431% asdf latest smlnj
110.98.1
```
